### PR TITLE
[SM,JR][OPS-4318] SDIL homepage direct debit support

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,15 @@ Handles the callback from tax enrolments when the subscription is activated.
 
 See [here](https://github.com/HMRC/tax-enrolments#put-tax-enrolmentssubscriptionssubscriptionidissuer) and [here](https://github.com/HMRC/tax-enrolments#put-tax-enrolmentssubscriptionssubscriptionidsubscriber) for details
 
+#### GET        /check-direct-debit-status/:sdilRef
+Looks for an existing active direct debit in ETMP.
+
+Returns 404 if the SDIL reference is not known.
+If the SDIL reference is known then and a has an active SDIL direct debit then a 200 response with a JSON response body is returned like:
+```{ "directDebitMandateFound" : true }```  
+If the SDIL reference is known then and does not have an active SDIL direct debit then a 200 response with a JSON response body is returned like:
+```{ "directDebitMandateFound" : false }```
+
 ## Running from source
 Clone the repository using SSH:
 

--- a/app/uk/gov/hmrc/softdrinksindustrylevy/config/ControllerWiring.scala
+++ b/app/uk/gov/hmrc/softdrinksindustrylevy/config/ControllerWiring.scala
@@ -40,6 +40,6 @@ trait ControllerWiring {
   lazy val variationsController: VariationsController = wire[VariationsController]
   lazy val returnsController: ReturnsController = wire[ReturnsController]
   lazy val balanceController: BalanceController = wire[BalanceController]
-  lazy val directDebitsController: DirectDebitsController = wire[DirectDebitsController]
+  lazy val directDebitsController: DirectDebitController = wire[DirectDebitController]
   val cc: ControllerComponents
 }

--- a/app/uk/gov/hmrc/softdrinksindustrylevy/config/ControllerWiring.scala
+++ b/app/uk/gov/hmrc/softdrinksindustrylevy/config/ControllerWiring.scala
@@ -40,6 +40,6 @@ trait ControllerWiring {
   lazy val variationsController: VariationsController = wire[VariationsController]
   lazy val returnsController: ReturnsController = wire[ReturnsController]
   lazy val balanceController: BalanceController = wire[BalanceController]
-  lazy val directDebitsController: DirectDebitsController= wire[DirectDebitsController]
+  lazy val directDebitsController: DirectDebitsController = wire[DirectDebitsController]
   val cc: ControllerComponents
 }

--- a/app/uk/gov/hmrc/softdrinksindustrylevy/config/ControllerWiring.scala
+++ b/app/uk/gov/hmrc/softdrinksindustrylevy/config/ControllerWiring.scala
@@ -40,5 +40,6 @@ trait ControllerWiring {
   lazy val variationsController: VariationsController = wire[VariationsController]
   lazy val returnsController: ReturnsController = wire[ReturnsController]
   lazy val balanceController: BalanceController = wire[BalanceController]
+  lazy val directDebitsController: DirectDebitsController= wire[DirectDebitsController]
   val cc: ControllerComponents
 }

--- a/app/uk/gov/hmrc/softdrinksindustrylevy/connectors/DesConnector.scala
+++ b/app/uk/gov/hmrc/softdrinksindustrylevy/connectors/DesConnector.scala
@@ -42,7 +42,7 @@ class DesConnector(
     extends DesHelpers(servicesConfig) with OptionHttpReads {
 
   val desURL: String = servicesConfig.baseUrl("des")
-  val desDisplayDirectDebitUrl: String = servicesConfig.baseUrl("desDisplayDD")
+  val desDirectDebitUrl: String = servicesConfig.baseUrl("des-direct-debit")
   val serviceURL: String = "soft-drinks"
   val cache: TMap[String, (Option[Subscription], LocalDateTime)] = TMap[String, (Option[Subscription], LocalDateTime)]()
 
@@ -144,7 +144,11 @@ class DesConnector(
       s"${encode(in._1, "UTF-8")}=${encode(in._2.toString, "UTF-8")}"
 
     val uri = s"$desURL/enterprise/financial-data/ZSDL/$sdilRef/ZSDL?" ++
-      args.map { encodePair }.mkString("&")
+      args
+        .map {
+          encodePair
+        }
+        .mkString("&")
 
     http.GET[Option[des.FinancialTransactionResponse]](uri)(implicitly, addHeaders, implicitly).flatMap { x =>
       x.map { y =>
@@ -154,10 +158,8 @@ class DesConnector(
     }
   }
 
-  def displayDirectDebit( sdilRef: String)(
-    implicit hc: HeaderCarrier
-  ):Future[DisplayDirectDebitResponse]={
-    val uri = s"$desURL/cross-regime/direct-debits/zsdl/zsdl/$sdilRef"
+  def displayDirectDebit(sdilRef: String)(implicit hc: HeaderCarrier): Future[DisplayDirectDebitResponse] = {
+    val uri = s"$desDirectDebitUrl/cross-regime/direct-debits/zsdl/zsdl/$sdilRef"
     http.GET[DisplayDirectDebitResponse](uri)(implicitly, addHeaders, implicitly)
   }
 

--- a/app/uk/gov/hmrc/softdrinksindustrylevy/connectors/DesConnector.scala
+++ b/app/uk/gov/hmrc/softdrinksindustrylevy/connectors/DesConnector.scala
@@ -42,6 +42,7 @@ class DesConnector(
     extends DesHelpers(servicesConfig) with OptionHttpReads {
 
   val desURL: String = servicesConfig.baseUrl("des")
+  val desDisplayDirectDebitUrl: String = servicesConfig.baseUrl("desDisplayDD")
   val serviceURL: String = "soft-drinks"
   val cache: TMap[String, (Option[Subscription], LocalDateTime)] = TMap[String, (Option[Subscription], LocalDateTime)]()
 
@@ -151,6 +152,13 @@ class DesConnector(
       }
       Future(x)
     }
+  }
+
+  def displayDirectDebit( sdilRef: String)(
+    implicit hc: HeaderCarrier
+  ):Future[DisplayDirectDebitResponse]={
+    val uri = s"$desURL/cross-regime/direct-debits/zsdl/zsdl/$sdilRef"
+    http.GET[DisplayDirectDebitResponse](uri)(implicitly, addHeaders, implicitly)
   }
 
   private def buildAuditEvent(body: FinancialTransactionResponse, path: String, subscriptionId: String)(

--- a/app/uk/gov/hmrc/softdrinksindustrylevy/controllers/DirectDebitController.scala
+++ b/app/uk/gov/hmrc/softdrinksindustrylevy/controllers/DirectDebitController.scala
@@ -23,7 +23,7 @@ import uk.gov.hmrc.softdrinksindustrylevy.connectors.DesConnector
 
 import scala.concurrent.ExecutionContext
 
-class DirectDebitsController(desConnector: DesConnector, val cc: ControllerComponents)(implicit ec: ExecutionContext)
+class DirectDebitController(desConnector: DesConnector, val cc: ControllerComponents)(implicit ec: ExecutionContext)
     extends BackendController(cc) {
 
   def checkDirectDebitStatus(sdilRef: String): Action[AnyContent] = Action.async { implicit request =>

--- a/app/uk/gov/hmrc/softdrinksindustrylevy/controllers/DirectDebitController.scala
+++ b/app/uk/gov/hmrc/softdrinksindustrylevy/controllers/DirectDebitController.scala
@@ -18,15 +18,20 @@ package uk.gov.hmrc.softdrinksindustrylevy.controllers
 
 import play.api.libs.json.Json
 import play.api.mvc.{Action, AnyContent, ControllerComponents}
+import uk.gov.hmrc.auth.core.AuthProvider.GovernmentGateway
+import uk.gov.hmrc.auth.core.{AuthConnector, AuthProviders, AuthorisedFunctions}
 import uk.gov.hmrc.play.bootstrap.controller.BackendController
 import uk.gov.hmrc.softdrinksindustrylevy.connectors.DesConnector
 
 import scala.concurrent.ExecutionContext
 
-class DirectDebitController(desConnector: DesConnector, val cc: ControllerComponents)(implicit ec: ExecutionContext)
-    extends BackendController(cc) {
+class DirectDebitController(desConnector: DesConnector, val cc: ControllerComponents, val authConnector: AuthConnector)(
+  implicit ec: ExecutionContext)
+    extends BackendController(cc) with AuthorisedFunctions {
 
   def checkDirectDebitStatus(sdilRef: String): Action[AnyContent] = Action.async { implicit request =>
-    desConnector.displayDirectDebit(sdilRef).map(response => Ok(Json.toJson(response)))
+    authorised(AuthProviders(GovernmentGateway)) {
+      desConnector.displayDirectDebit(sdilRef).map(response => Ok(Json.toJson(response)))
+    }
   }
 }

--- a/app/uk/gov/hmrc/softdrinksindustrylevy/controllers/DirectDebitsController.scala
+++ b/app/uk/gov/hmrc/softdrinksindustrylevy/controllers/DirectDebitsController.scala
@@ -1,0 +1,17 @@
+package uk.gov.hmrc.softdrinksindustrylevy.controllers
+
+import play.api.mvc.{Action, AnyContent, ControllerComponents}
+import uk.gov.hmrc.play.bootstrap.controller.BackendController
+import uk.gov.hmrc.softdrinksindustrylevy.connectors.DesConnector
+
+class DirectDebitsController(desConnector: DesConnector,
+                             val cc: ControllerComponents
+                            )
+  extends BackendController(cc) {
+
+  def checkDdStatus(sdilRef:String):Action[AnyContent] = Action.async { implicit request =>
+    for {
+      response <- desConnector.displayDirectDebit(sdilRef)
+    }yield if(response.directDebitMandateFound)NoContent else NotFound
+  }
+}

--- a/app/uk/gov/hmrc/softdrinksindustrylevy/controllers/DirectDebitsController.scala
+++ b/app/uk/gov/hmrc/softdrinksindustrylevy/controllers/DirectDebitsController.scala
@@ -26,7 +26,7 @@ import scala.concurrent.ExecutionContext
 class DirectDebitsController(desConnector: DesConnector, val cc: ControllerComponents)(implicit ec: ExecutionContext)
     extends BackendController(cc) {
 
-  def checkDdStatus(sdilRef: String): Action[AnyContent] = Action.async { implicit request =>
+  def checkDirectDebitStatus(sdilRef: String): Action[AnyContent] = Action.async { implicit request =>
     desConnector.displayDirectDebit(sdilRef).map(response => Ok(Json.toJson(response)))
   }
 }

--- a/app/uk/gov/hmrc/softdrinksindustrylevy/controllers/DirectDebitsController.scala
+++ b/app/uk/gov/hmrc/softdrinksindustrylevy/controllers/DirectDebitsController.scala
@@ -1,17 +1,32 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package uk.gov.hmrc.softdrinksindustrylevy.controllers
 
+import play.api.libs.json.Json
 import play.api.mvc.{Action, AnyContent, ControllerComponents}
 import uk.gov.hmrc.play.bootstrap.controller.BackendController
 import uk.gov.hmrc.softdrinksindustrylevy.connectors.DesConnector
 
-class DirectDebitsController(desConnector: DesConnector,
-                             val cc: ControllerComponents
-                            )
-  extends BackendController(cc) {
+import scala.concurrent.ExecutionContext
 
-  def checkDdStatus(sdilRef:String):Action[AnyContent] = Action.async { implicit request =>
-    for {
-      response <- desConnector.displayDirectDebit(sdilRef)
-    }yield if(response.directDebitMandateFound)NoContent else NotFound
+class DirectDebitsController(desConnector: DesConnector, val cc: ControllerComponents)(implicit ec: ExecutionContext)
+    extends BackendController(cc) {
+
+  def checkDdStatus(sdilRef: String): Action[AnyContent] = Action.async { implicit request =>
+    desConnector.displayDirectDebit(sdilRef).map(response => Ok(Json.toJson(response)))
   }
 }

--- a/app/uk/gov/hmrc/softdrinksindustrylevy/models/DisplayDirectDebitResponse.scala
+++ b/app/uk/gov/hmrc/softdrinksindustrylevy/models/DisplayDirectDebitResponse.scala
@@ -1,0 +1,9 @@
+package uk.gov.hmrc.softdrinksindustrylevy.models
+
+import play.api.libs.json.{Format, Json}
+
+case class DisplayDirectDebitResponse(directDebitMandateFound: Boolean)
+
+object DisplayDirectDebitResponse {
+  implicit val format: Format[DisplayDirectDebitResponse] = Json.format[DisplayDirectDebitResponse]
+}

--- a/app/uk/gov/hmrc/softdrinksindustrylevy/models/DisplayDirectDebitResponse.scala
+++ b/app/uk/gov/hmrc/softdrinksindustrylevy/models/DisplayDirectDebitResponse.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package uk.gov.hmrc.softdrinksindustrylevy.models
 
 import play.api.libs.json.{Format, Json}

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -22,3 +22,5 @@ POST        /returns/vary/:sdilRef                                           uk.
 GET         /balance/:sdil/history/:year                                     uk.gov.hmrc.softdrinksindustrylevy.controllers.BalanceController.balanceHistory(sdil: String, year: Int)
 GET         /balance/:sdil/history/all/:withAssessment                       uk.gov.hmrc.softdrinksindustrylevy.controllers.BalanceController.balanceHistoryAll(sdil: String, withAssessment: Boolean)
 GET         /balance/:sdil/:withAssessment                                   uk.gov.hmrc.softdrinksindustrylevy.controllers.BalanceController.balance(sdil: String, withAssessment: Boolean)
+
+GET         /direct-debit-status/:sdilRef                                    uk.gov.hmrc.softdrinksindustrylevy.controllers.DirectDebitsController.checkDdStatus(sdilRef: String)

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -23,4 +23,4 @@ GET         /balance/:sdil/history/:year                                     uk.
 GET         /balance/:sdil/history/all/:withAssessment                       uk.gov.hmrc.softdrinksindustrylevy.controllers.BalanceController.balanceHistoryAll(sdil: String, withAssessment: Boolean)
 GET         /balance/:sdil/:withAssessment                                   uk.gov.hmrc.softdrinksindustrylevy.controllers.BalanceController.balance(sdil: String, withAssessment: Boolean)
 
-GET         /direct-debit-status/:sdilRef                                    uk.gov.hmrc.softdrinksindustrylevy.controllers.DirectDebitsController.checkDdStatus(sdilRef: String)
+GET         /check-direct-debit-status/:sdilRef                              uk.gov.hmrc.softdrinksindustrylevy.controllers.DirectDebitsController.checkDdStatus(sdilRef: String)

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -23,4 +23,4 @@ GET         /balance/:sdil/history/:year                                     uk.
 GET         /balance/:sdil/history/all/:withAssessment                       uk.gov.hmrc.softdrinksindustrylevy.controllers.BalanceController.balanceHistoryAll(sdil: String, withAssessment: Boolean)
 GET         /balance/:sdil/:withAssessment                                   uk.gov.hmrc.softdrinksindustrylevy.controllers.BalanceController.balance(sdil: String, withAssessment: Boolean)
 
-GET         /check-direct-debit-status/:sdilRef                              uk.gov.hmrc.softdrinksindustrylevy.controllers.DirectDebitsController.checkDdStatus(sdilRef: String)
+GET         /check-direct-debit-status/:sdilRef                              uk.gov.hmrc.softdrinksindustrylevy.controllers.DirectDebitsController.checkDirectDebitStatus(sdilRef: String)

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -23,4 +23,4 @@ GET         /balance/:sdil/history/:year                                     uk.
 GET         /balance/:sdil/history/all/:withAssessment                       uk.gov.hmrc.softdrinksindustrylevy.controllers.BalanceController.balanceHistoryAll(sdil: String, withAssessment: Boolean)
 GET         /balance/:sdil/:withAssessment                                   uk.gov.hmrc.softdrinksindustrylevy.controllers.BalanceController.balance(sdil: String, withAssessment: Boolean)
 
-GET         /check-direct-debit-status/:sdilRef                              uk.gov.hmrc.softdrinksindustrylevy.controllers.DirectDebitsController.checkDirectDebitStatus(sdilRef: String)
+GET         /check-direct-debit-status/:sdilRef                              uk.gov.hmrc.softdrinksindustrylevy.controllers.DirectDebitController.checkDirectDebitStatus(sdilRef: String)

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -168,6 +168,11 @@ microservice {
       environment = "live"
     }
 
+    desDisplayDD{
+      host = localhost
+      port = 9078
+    }
+
     tax-enrolments {
       host = localhost
       port = 9995

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -168,7 +168,7 @@ microservice {
       environment = "live"
     }
 
-    desDisplayDD{
+    des-direct-debit {
       host = localhost
       port = 9078
     }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -171,8 +171,6 @@ microservice {
     des-direct-debit {
       host = localhost
       port = 9078
-      token = ${microservice.services.des.token}
-      environment = ${microservice.services.des.environment}
     }
 
     tax-enrolments {

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -171,6 +171,8 @@ microservice {
     des-direct-debit {
       host = localhost
       port = 9078
+      token = ${microservice.services.des.token}
+      environment = ${microservice.services.des.environment}
     }
 
     tax-enrolments {

--- a/test/uk/gov/hmrc/softdrinksindustrylevy/connectors/DesConnectorSpec.scala
+++ b/test/uk/gov/hmrc/softdrinksindustrylevy/connectors/DesConnectorSpec.scala
@@ -25,7 +25,7 @@ import play.api.libs.json._
 import sdil.models.des
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.softdrinksindustrylevy.models._
-import uk.gov.hmrc.softdrinksindustrylevy.models.connectors.{arbActivity, arbAddress, arbContact, arbSubRequest, sub, arbDisplayDirectDebitResponse}
+import uk.gov.hmrc.softdrinksindustrylevy.models.connectors.{arbActivity, arbAddress, arbContact, arbDisplayDirectDebitResponse, arbSubRequest, sub}
 
 class DesConnectorSpecPropertyBased extends FunSuite with ScalaCheckPropertyChecks with Matchers {
 
@@ -55,9 +55,9 @@ class DesConnectorSpecPropertyBased extends FunSuite with ScalaCheckPropertyChec
     }
   }
 
-  test("∀ DisplayDirectDebitResponse: parse(toJson(x)) = x"){
+  test("∀ DisplayDirectDebitResponse: parse(toJson(x)) = x") {
     forAll { r: DisplayDirectDebitResponse =>
-      Json.toJson(r).as[DisplayDirectDebitResponse] should be (r)
+      Json.toJson(r).as[DisplayDirectDebitResponse] should be(r)
     }
   }
 
@@ -145,7 +145,7 @@ class DesConnectorSpecBehavioural extends WiremockSpec {
     "displayDirectDebit should return Future true when des returns directDebitMandateResponse set to true" in {
       stubFor(
         get(urlEqualTo("/cross-regime/direct-debits/zsdl/zsdl/XMSDIL000000001"))
-          .willReturn(aResponse().withBody( """{ "directDebitMandateFound" : true }""").withStatus(200)))
+          .willReturn(aResponse().withBody("""{ "directDebitMandateFound" : true }""").withStatus(200)))
       val response = TestDesConnector.displayDirectDebit("XMSDIL000000001").futureValue
       response.directDebitMandateFound mustBe true
     }
@@ -153,7 +153,7 @@ class DesConnectorSpecBehavioural extends WiremockSpec {
     "displayDirectDebit should return Future false when des returns directDebitMandateResponse set to false" in {
       stubFor(
         get(urlEqualTo("/cross-regime/direct-debits/zsdl/zsdl/XMSDIL000000001"))
-          .willReturn(aResponse().withBody( """{ "directDebitMandateFound" : false }""").withStatus(200)))
+          .willReturn(aResponse().withBody("""{ "directDebitMandateFound" : false }""").withStatus(200)))
       val response = TestDesConnector.displayDirectDebit("XMSDIL000000001").futureValue
       response.directDebitMandateFound mustBe false
     }
@@ -162,11 +162,10 @@ class DesConnectorSpecBehavioural extends WiremockSpec {
       stubFor(
         get(urlEqualTo("/cross-regime/direct-debits/zsdl/zsdl/XMSDIL000000001"))
           .willReturn(aResponse().withStatus(404)))
-      val response =  the[Exception] thrownBy (TestDesConnector
+      val response = the[Exception] thrownBy (TestDesConnector
         .displayDirectDebit("XMSDIL000000001")
         .futureValue)
-      response.getMessage must startWith(
-        "The future returned an exception of type: uk.gov.hmrc.http.NotFoundException")
+      response.getMessage must startWith("The future returned an exception of type: uk.gov.hmrc.http.NotFoundException")
     }
   }
 

--- a/test/uk/gov/hmrc/softdrinksindustrylevy/connectors/DesConnectorSpec.scala
+++ b/test/uk/gov/hmrc/softdrinksindustrylevy/connectors/DesConnectorSpec.scala
@@ -25,7 +25,7 @@ import play.api.libs.json._
 import sdil.models.des
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.softdrinksindustrylevy.models._
-import uk.gov.hmrc.softdrinksindustrylevy.models.connectors.{arbActivity, arbAddress, arbContact, arbSubRequest, sub}
+import uk.gov.hmrc.softdrinksindustrylevy.models.connectors.{arbActivity, arbAddress, arbContact, arbSubRequest, sub, arbDisplayDirectDebitResponse}
 
 class DesConnectorSpecPropertyBased extends FunSuite with ScalaCheckPropertyChecks with Matchers {
 
@@ -55,6 +55,12 @@ class DesConnectorSpecPropertyBased extends FunSuite with ScalaCheckPropertyChec
     }
   }
 
+  test("∀ DisplayDirectDebitResponse: parse(toJson(x)) = x"){
+    forAll { r: DisplayDirectDebitResponse =>
+      Json.toJson(r).as[DisplayDirectDebitResponse] should be (r)
+    }
+  }
+
 }
 
 class DesConnectorSpecBehavioural extends WiremockSpec {
@@ -69,6 +75,7 @@ class DesConnectorSpecBehavioural extends WiremockSpec {
   object TestDesConnector
       extends DesConnector(httpClient, environment.mode, servicesConfig, testPersistence, auditConnector) {
     override val desURL: String = mockServerUrl
+    override val desDirectDebitUrl: String = mockServerUrl
   }
 
   "DesConnector" should {
@@ -133,6 +140,33 @@ class DesConnectorSpecBehavioural extends WiremockSpec {
         .futureValue)
       response.getMessage must startWith(
         "The future returned an exception of type: uk.gov.hmrc.http.Upstream5xxResponse")
+    }
+
+    "displayDirectDebit should return Future true when des returns directDebitMandateResponse set to true" in {
+      stubFor(
+        get(urlEqualTo("/cross-regime/direct-debits/zsdl/zsdl/XMSDIL000000001"))
+          .willReturn(aResponse().withBody( """{ "directDebitMandateFound" : true }""").withStatus(200)))
+      val response = TestDesConnector.displayDirectDebit("XMSDIL000000001").futureValue
+      response.directDebitMandateFound mustBe true
+    }
+
+    "displayDirectDebit should return Future false when des returns directDebitMandateResponse set to false" in {
+      stubFor(
+        get(urlEqualTo("/cross-regime/direct-debits/zsdl/zsdl/XMSDIL000000001"))
+          .willReturn(aResponse().withBody( """{ "directDebitMandateFound" : false }""").withStatus(200)))
+      val response = TestDesConnector.displayDirectDebit("XMSDIL000000001").futureValue
+      response.directDebitMandateFound mustBe false
+    }
+
+    "displayDirectDebit should return Failed future when Des returns a 404" in {
+      stubFor(
+        get(urlEqualTo("/cross-regime/direct-debits/zsdl/zsdl/XMSDIL000000001"))
+          .willReturn(aResponse().withStatus(404)))
+      val response =  the[Exception] thrownBy (TestDesConnector
+        .displayDirectDebit("XMSDIL000000001")
+        .futureValue)
+      response.getMessage must startWith(
+        "The future returned an exception of type: uk.gov.hmrc.http.NotFoundException")
     }
   }
 

--- a/test/uk/gov/hmrc/softdrinksindustrylevy/connectors/package.scala
+++ b/test/uk/gov/hmrc/softdrinksindustrylevy/connectors/package.scala
@@ -36,7 +36,7 @@ package object connectors {
   val genEmail: Gen[String] = for {
     prefix <- nonEmptyString.map(_.take(10))
     domain <- nonEmptyString.map(_.take(10))
-    tld    <- Gen.oneOf("com", "co.uk")
+    tld <- Gen.oneOf("com", "co.uk")
   } yield {
     s"$prefix@$domain.$tld"
   }
@@ -73,14 +73,14 @@ package object connectors {
 
   val genActivity: Gen[Activity] = for {
     types <- genActivityTypes flatMap (s =>
-              s map { t =>
-                t.flatten
-              })
+      s map { t =>
+        t.flatten
+      })
     typeTuples <- Gen.sequence(types.map { typeL =>
-                   genLitreBands.flatMap {
-                     typeL -> _
-                   }
-                 })
+      genLitreBands.flatMap {
+        typeL -> _
+      }
+    })
     isLarge <- Gen.boolean
   } yield {
     InternalActivity(typeTuples.asScala.toMap, isLarge)
@@ -93,10 +93,10 @@ package object connectors {
 
   val genRetrievedActivity: Gen[Activity] =
     for {
-      isLarge          <- Gen.boolean
-      isProducer       <- genIsProducer(isLarge)
+      isLarge <- Gen.boolean
+      isProducer <- genIsProducer(isLarge)
       isContractPacker <- Gen.boolean
-      isImporter       <- Gen.boolean
+      isImporter <- Gen.boolean
     } yield RetrievedActivity(isProducer, isLarge, isContractPacker, isImporter)
 
   val genName: Gen[String] = for {
@@ -105,23 +105,23 @@ package object connectors {
   } yield s"$fname $sname"
 
   val genContact: Gen[Contact] = for {
-    fname             <- Gen.forename
-    sname             <- Gen.surname
+    fname <- Gen.forename
+    sname <- Gen.surname
     positionInCompany <- nonEmptyString
-    phoneNumber       <- Gen.ukPhoneNumber
-    email             <- genEmail
+    phoneNumber <- Gen.ukPhoneNumber
+    email <- genEmail
   } yield Contact(Some(s"$fname $sname"), Some(positionInCompany), phoneNumber, email)
 
   val genSubscription: Gen[Subscription] = for {
-    utr             <- Enumerable.instances.utrEnum.gen
-    orgName         <- nonEmptyString
-    orgType         <- Gen.oneOf("1", "2", "3", "5", "7")
-    address         <- genUkAddress
-    activity        <- genActivity
-    liabilityDate   <- Gen.date
+    utr <- Enumerable.instances.utrEnum.gen
+    orgName <- nonEmptyString
+    orgType <- Gen.oneOf("1", "2", "3", "5", "7")
+    address <- genUkAddress
+    activity <- genActivity
+    liabilityDate <- Gen.date
     productionSites <- Gen.listOf(genSite)
-    warehouseSites  <- Gen.listOf(genSite)
-    contact         <- genContact
+    warehouseSites <- Gen.listOf(genSite)
+    contact <- genContact
   } yield
     Subscription(
       utr,
@@ -137,21 +137,21 @@ package object connectors {
       None)
 
   val genSite: Gen[Site] = for {
-    ref         <- Gen.oneOf("a", "b")
-    address     <- genUkAddress
+    ref <- Gen.oneOf("a", "b")
+    address <- genUkAddress
     tradingName <- genName
   } yield Site(address, Some(ref), Some(tradingName), None)
 
   def genRetrievedSubscription: Gen[Subscription] =
     for {
-      utr             <- Enumerable.instances.utrEnum.gen
-      orgName         <- nonEmptyString
-      address         <- genUkAddress
-      activity        <- genRetrievedActivity
-      liabilityDate   <- Gen.date
+      utr <- Enumerable.instances.utrEnum.gen
+      orgName <- nonEmptyString
+      address <- genUkAddress
+      activity <- genRetrievedActivity
+      liabilityDate <- Gen.date
       productionSites <- Gen.listOf(genUkAddress map addressToSite)
-      warehouseSites  <- Gen.listOf(genUkAddress map addressToSite)
-      contact         <- genContact
+      warehouseSites <- Gen.listOf(genUkAddress map addressToSite)
+      contact <- genContact
     } yield
       Subscription(
         utr,
@@ -168,14 +168,14 @@ package object connectors {
 
   val genSdil: Gen[String] = {
     for {
-      char   <- Gen.alphaUpperChar
+      char <- Gen.alphaUpperChar
       suffix <- pattern"999999"
     } yield s"X${char}SDIL000$suffix"
   }
 
   val genReturnsSmallProducerVolume: Gen[SmallProducerVolume] = {
     for {
-      ref    <- genSdil
+      ref <- genSdil
       litres <- genLitreBands
     } yield SmallProducerVolume(ref, litres)
   }
@@ -183,7 +183,7 @@ package object connectors {
   val genReturnsPackaging: Gen[ReturnsPackaging] = {
     for {
       smallProds <- Gen.listOf(genReturnsSmallProducerVolume)
-      litres     <- genLitreBands
+      litres <- genLitreBands
     } yield ReturnsPackaging(smallProds, litres)
   }
 
@@ -199,8 +199,15 @@ package object connectors {
       packaged <- genReturnsPackaging.sometimes
       imported <- genReturnsImporting.sometimes
       exported <- genLitreBands.sometimes
-      wastage  <- genLitreBands.sometimes
+      wastage <- genLitreBands.sometimes
     } yield ReturnsRequest(packaged, imported, exported, wastage)
+  }
+
+  val genDisplayDirectDebitResponse: Gen[DisplayDirectDebitResponse] = {
+    for {
+      directDebitMandateFound <- Gen.boolean
+    } yield DisplayDirectDebitResponse(directDebitMandateFound)
+
   }
 
   implicit val arbSubGet = Arbitrary(genRetrievedSubscription)
@@ -210,6 +217,7 @@ package object connectors {
   implicit val arbSite = Arbitrary(genSite)
   implicit val arbSubRequest = Arbitrary(genSubscription)
   implicit val arbReturnReq = Arbitrary(genReturnsRequest)
+  implicit val arbDisplayDirectDebitResponse = Arbitrary(genDisplayDirectDebitResponse)
 
   val sub = Subscription(
     "1234567890",
@@ -227,16 +235,16 @@ package object connectors {
   )
 
   def internalActivity(
-    produced: LitreBands = zero,
-    copackedAll: LitreBands = zero,
-    imported: LitreBands = zero,
-    copackedByOthers: LitreBands = zero) =
+                        produced: LitreBands = zero,
+                        copackedAll: LitreBands = zero,
+                        imported: LitreBands = zero,
+                        copackedByOthers: LitreBands = zero) =
     InternalActivity(
       Map(
         ProducedOwnBrand -> produced,
-        CopackerAll      -> copackedAll,
-        Imported         -> imported,
-        Copackee         -> copackedByOthers
+        CopackerAll -> copackedAll,
+        Imported -> imported,
+        Copackee -> copackedByOthers
       ),
       false
     )

--- a/test/uk/gov/hmrc/softdrinksindustrylevy/connectors/package.scala
+++ b/test/uk/gov/hmrc/softdrinksindustrylevy/connectors/package.scala
@@ -36,7 +36,7 @@ package object connectors {
   val genEmail: Gen[String] = for {
     prefix <- nonEmptyString.map(_.take(10))
     domain <- nonEmptyString.map(_.take(10))
-    tld <- Gen.oneOf("com", "co.uk")
+    tld    <- Gen.oneOf("com", "co.uk")
   } yield {
     s"$prefix@$domain.$tld"
   }
@@ -73,14 +73,14 @@ package object connectors {
 
   val genActivity: Gen[Activity] = for {
     types <- genActivityTypes flatMap (s =>
-      s map { t =>
-        t.flatten
-      })
+              s map { t =>
+                t.flatten
+              })
     typeTuples <- Gen.sequence(types.map { typeL =>
-      genLitreBands.flatMap {
-        typeL -> _
-      }
-    })
+                   genLitreBands.flatMap {
+                     typeL -> _
+                   }
+                 })
     isLarge <- Gen.boolean
   } yield {
     InternalActivity(typeTuples.asScala.toMap, isLarge)
@@ -93,10 +93,10 @@ package object connectors {
 
   val genRetrievedActivity: Gen[Activity] =
     for {
-      isLarge <- Gen.boolean
-      isProducer <- genIsProducer(isLarge)
+      isLarge          <- Gen.boolean
+      isProducer       <- genIsProducer(isLarge)
       isContractPacker <- Gen.boolean
-      isImporter <- Gen.boolean
+      isImporter       <- Gen.boolean
     } yield RetrievedActivity(isProducer, isLarge, isContractPacker, isImporter)
 
   val genName: Gen[String] = for {
@@ -105,23 +105,23 @@ package object connectors {
   } yield s"$fname $sname"
 
   val genContact: Gen[Contact] = for {
-    fname <- Gen.forename
-    sname <- Gen.surname
+    fname             <- Gen.forename
+    sname             <- Gen.surname
     positionInCompany <- nonEmptyString
-    phoneNumber <- Gen.ukPhoneNumber
-    email <- genEmail
+    phoneNumber       <- Gen.ukPhoneNumber
+    email             <- genEmail
   } yield Contact(Some(s"$fname $sname"), Some(positionInCompany), phoneNumber, email)
 
   val genSubscription: Gen[Subscription] = for {
-    utr <- Enumerable.instances.utrEnum.gen
-    orgName <- nonEmptyString
-    orgType <- Gen.oneOf("1", "2", "3", "5", "7")
-    address <- genUkAddress
-    activity <- genActivity
-    liabilityDate <- Gen.date
+    utr             <- Enumerable.instances.utrEnum.gen
+    orgName         <- nonEmptyString
+    orgType         <- Gen.oneOf("1", "2", "3", "5", "7")
+    address         <- genUkAddress
+    activity        <- genActivity
+    liabilityDate   <- Gen.date
     productionSites <- Gen.listOf(genSite)
-    warehouseSites <- Gen.listOf(genSite)
-    contact <- genContact
+    warehouseSites  <- Gen.listOf(genSite)
+    contact         <- genContact
   } yield
     Subscription(
       utr,
@@ -137,21 +137,21 @@ package object connectors {
       None)
 
   val genSite: Gen[Site] = for {
-    ref <- Gen.oneOf("a", "b")
-    address <- genUkAddress
+    ref         <- Gen.oneOf("a", "b")
+    address     <- genUkAddress
     tradingName <- genName
   } yield Site(address, Some(ref), Some(tradingName), None)
 
   def genRetrievedSubscription: Gen[Subscription] =
     for {
-      utr <- Enumerable.instances.utrEnum.gen
-      orgName <- nonEmptyString
-      address <- genUkAddress
-      activity <- genRetrievedActivity
-      liabilityDate <- Gen.date
+      utr             <- Enumerable.instances.utrEnum.gen
+      orgName         <- nonEmptyString
+      address         <- genUkAddress
+      activity        <- genRetrievedActivity
+      liabilityDate   <- Gen.date
       productionSites <- Gen.listOf(genUkAddress map addressToSite)
-      warehouseSites <- Gen.listOf(genUkAddress map addressToSite)
-      contact <- genContact
+      warehouseSites  <- Gen.listOf(genUkAddress map addressToSite)
+      contact         <- genContact
     } yield
       Subscription(
         utr,
@@ -168,14 +168,14 @@ package object connectors {
 
   val genSdil: Gen[String] = {
     for {
-      char <- Gen.alphaUpperChar
+      char   <- Gen.alphaUpperChar
       suffix <- pattern"999999"
     } yield s"X${char}SDIL000$suffix"
   }
 
   val genReturnsSmallProducerVolume: Gen[SmallProducerVolume] = {
     for {
-      ref <- genSdil
+      ref    <- genSdil
       litres <- genLitreBands
     } yield SmallProducerVolume(ref, litres)
   }
@@ -183,7 +183,7 @@ package object connectors {
   val genReturnsPackaging: Gen[ReturnsPackaging] = {
     for {
       smallProds <- Gen.listOf(genReturnsSmallProducerVolume)
-      litres <- genLitreBands
+      litres     <- genLitreBands
     } yield ReturnsPackaging(smallProds, litres)
   }
 
@@ -199,7 +199,7 @@ package object connectors {
       packaged <- genReturnsPackaging.sometimes
       imported <- genReturnsImporting.sometimes
       exported <- genLitreBands.sometimes
-      wastage <- genLitreBands.sometimes
+      wastage  <- genLitreBands.sometimes
     } yield ReturnsRequest(packaged, imported, exported, wastage)
   }
 
@@ -235,16 +235,16 @@ package object connectors {
   )
 
   def internalActivity(
-                        produced: LitreBands = zero,
-                        copackedAll: LitreBands = zero,
-                        imported: LitreBands = zero,
-                        copackedByOthers: LitreBands = zero) =
+    produced: LitreBands = zero,
+    copackedAll: LitreBands = zero,
+    imported: LitreBands = zero,
+    copackedByOthers: LitreBands = zero) =
     InternalActivity(
       Map(
         ProducedOwnBrand -> produced,
-        CopackerAll -> copackedAll,
-        Imported -> imported,
-        Copackee -> copackedByOthers
+        CopackerAll      -> copackedAll,
+        Imported         -> imported,
+        Copackee         -> copackedByOthers
       ),
       false
     )

--- a/test/uk/gov/hmrc/softdrinksindustrylevy/controllers/DirectDebitControllerSpec.scala
+++ b/test/uk/gov/hmrc/softdrinksindustrylevy/controllers/DirectDebitControllerSpec.scala
@@ -1,0 +1,64 @@
+package uk.gov.hmrc.softdrinksindustrylevy.controllers
+
+import org.mockito.ArgumentMatchers.any
+import com.softwaremill.macwire.wire
+import org.mockito.Mockito.{reset, times, verify, when}
+import play.api.test.Helpers._
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatestplus.mockito.MockitoSugar
+import play.api.libs.json.Json
+import play.api.test.FakeRequest
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.softdrinksindustrylevy.config.SdilComponents
+import uk.gov.hmrc.softdrinksindustrylevy.connectors.DesConnector
+import uk.gov.hmrc.softdrinksindustrylevy.models.DisplayDirectDebitResponse
+import uk.gov.hmrc.softdrinksindustrylevy.util.FakeApplicationSpec
+import uk.gov.hmrc.http.NotFoundException
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+class DirectDebitControllerSpec extends FakeApplicationSpec with MockitoSugar with BeforeAndAfterEach with ScalaFutures{
+
+  val mockDesConnector: DesConnector = mock[DesConnector]
+  lazy val cc = new SdilComponents(context).cc
+  val testDirectDebitController = wire[DirectDebitController]
+
+
+  implicit val hc: HeaderCarrier = new HeaderCarrier
+
+
+  override def beforeEach() {
+    reset(mockDesConnector)
+  }
+
+  "DirectDebitController" should {
+    "return an OK with a DirectDebitResponse" in {
+      when(mockDesConnector.displayDirectDebit(any())(any())).thenReturn(Future.successful(DisplayDirectDebitResponse(true)))
+
+      val response = testDirectDebitController.checkDirectDebitStatus("XMSDIL000000001")(FakeRequest())
+
+      status(response) mustBe OK
+      verify(mockDesConnector, times(1)).displayDirectDebit(any())(any())
+      contentAsJson(response) mustBe Json.parse(
+        """{
+          |   "directDebitMandateFound" : true
+          |}""".stripMargin)
+    }
+
+    "return an 404 when des returns a NotFoundException " in {
+
+      val mockedException = Future.failed(new NotFoundException(""))
+
+      when(mockDesConnector.displayDirectDebit(any())(any())).thenReturn(mockedException)
+
+      val exception = the[Exception] thrownBy testDirectDebitController.checkDirectDebitStatus("XMSDIL000000001")(FakeRequest()).futureValue
+
+      exception mustBe a[NotFoundException]
+      verify(mockDesConnector, times(1)).displayDirectDebit(any())(any())
+    }
+
+  }
+
+}

--- a/test/uk/gov/hmrc/softdrinksindustrylevy/controllers/DirectDebitControllerSpec.scala
+++ b/test/uk/gov/hmrc/softdrinksindustrylevy/controllers/DirectDebitControllerSpec.scala
@@ -26,6 +26,7 @@ import org.scalatestplus.mockito.MockitoSugar
 import play.api.libs.json.Json
 import play.api.mvc.Result
 import play.api.test.FakeRequest
+import uk.gov.hmrc.auth.core.AuthConnector
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.softdrinksindustrylevy.config.SdilComponents
 import uk.gov.hmrc.softdrinksindustrylevy.connectors.DesConnector
@@ -41,6 +42,7 @@ class DirectDebitControllerSpec
 
   val mockDesConnector: DesConnector = mock[DesConnector]
   lazy val cc = new SdilComponents(context).cc
+  val mockAuthConnector: AuthConnector = mock[AuthConnector]
   val testDirectDebitController = wire[DirectDebitController]
 
   implicit val hc: HeaderCarrier = new HeaderCarrier
@@ -48,6 +50,8 @@ class DirectDebitControllerSpec
   override def beforeEach() {
     reset(mockDesConnector)
   }
+
+  when(mockAuthConnector.authorise[Unit](any(), any())(any(), any())).thenReturn(Future.successful(()))
 
   "DirectDebitController" should {
     "return an OK with a DirectDebitResponse" in {


### PR DESCRIPTION
This adds a new endpoint to check the status of a customer's SDIL direct debits, whether they have one set up or not. It's called by the `soft-drinks-industry-levy-frontend`

The `direct-debit-stubs` have been used to provide stub support for the DES #1396 "Display Direct Debit" API. This required adding a config to `application.conf` called `des-direct-debit` so that it could be directed to a host/port different to the `soft-drinks-industry-levy-stub` for this API. The `token` and `environment` configs however just reference those in the usual `des` config.