### PR TITLE
DM-7 | Add missing etmp prefix to hip path, that's missing from spec

### DIFF
--- a/app/uk/gov/hmrc/softdrinksindustrylevy/connectors/HipConnector.scala
+++ b/app/uk/gov/hmrc/softdrinksindustrylevy/connectors/HipConnector.scala
@@ -52,7 +52,7 @@ class HipConnector @Inject() (
   private val hipBaseURL: String = servicesConfig.baseUrl("hip")
   private val hipClientId: String = servicesConfig.getString("microservice.services.hip.clientId")
   private val hipClientSecret: String = servicesConfig.getString("microservice.services.hip.clientSecret")
-  private val hipApiRoot: String = "RESTAdapter/soft-drinks"
+  private val hipApiRoot: String = "etmp/RESTAdapter/soft-drinks"
   private val hipIdNotFoundCode: String = "002"
   private val hipObligationAlreadyFulfilledCode: String = "044"
 

--- a/test/uk/gov/hmrc/softdrinksindustrylevy/connectors/HipConnectorSpec.scala
+++ b/test/uk/gov/hmrc/softdrinksindustrylevy/connectors/HipConnectorSpec.scala
@@ -47,7 +47,7 @@ class HipConnectorSpec extends FakeApplicationSpec with HttpClientV2Helper with 
 
   private val HIP_AUTHORIZATION: String = "Basic Y2xpZW50LWlkOmNsaWVudC1zZWNyZXQ="
 
-  private val HIP_API_ROOT: String = "/RESTAdapter/soft-drinks"
+  private val HIP_API_ROOT: String = "/etmp/RESTAdapter/soft-drinks"
 
   val hipConnector: HipConnector = app.injector.instanceOf[HipConnector]
 


### PR DESCRIPTION
- Spec has incorrectly defined the path definitions due to which the `etmp` prefix was initially missed out.